### PR TITLE
Add simple farming prototype

### DIFF
--- a/FarmGrid.gd
+++ b/FarmGrid.gd
@@ -1,0 +1,17 @@
+extends Node2D
+
+const GRID_WIDTH := 5
+const GRID_HEIGHT := 5
+const TILE_SIZE := 32
+
+var tiles = []
+
+func _ready():
+    var tile_scene = preload("res://FarmTile.tscn")
+    for y in range(GRID_HEIGHT):
+        tiles.append([])
+        for x in range(GRID_WIDTH):
+            var tile = tile_scene.instantiate()
+            tile.position = Vector2(x * TILE_SIZE, y * TILE_SIZE)
+            add_child(tile)
+            tiles[y].append(tile)

--- a/FarmTile.gd
+++ b/FarmTile.gd
@@ -1,0 +1,33 @@
+extends Node2D
+
+enum State { UNTILLED, TILLED, PLANTED, GROWN }
+var state : State = State.UNTILLED
+
+func _ready():
+    update()
+
+func _draw():
+    var color = Color(0.4, 0.3, 0.1)
+    match state:
+        State.TILLED:
+            color = Color(0.5, 0.4, 0.2)
+        State.PLANTED:
+            color = Color(0.2, 0.6, 0.2)
+        State.GROWN:
+            color = Color(0.1, 0.8, 0.1)
+    draw_rect(Rect2(Vector2.ZERO, Vector2(32, 32)), color)
+
+func till():
+    if state == State.UNTILLED:
+        state = State.TILLED
+        update()
+
+func plant():
+    if state == State.TILLED:
+        state = State.PLANTED
+        update()
+
+func grow():
+    if state == State.PLANTED:
+        state = State.GROWN
+        update()

--- a/FarmTile.tscn
+++ b/FarmTile.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://FarmTile.gd" type="Script" id="1"]
+
+[node name="FarmTile" type="Node2D"]
+script = ExtResource("1")

--- a/GameManager.gd
+++ b/GameManager.gd
@@ -1,0 +1,6 @@
+extends Node
+
+# Placeholder autoload script
+
+func _ready():
+    pass

--- a/LocationManager.gd
+++ b/LocationManager.gd
@@ -1,0 +1,6 @@
+extends Node
+
+# Placeholder autoload script
+
+func _ready():
+    pass

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://Player.gd" type="Script" id="1"]
+[ext_resource path="res://FarmGrid.gd" type="Script" id="2"]
+
+[node name="Main" type="Node2D"]
+
+[node name="Farm" type="Node2D" parent="."]
+script = ExtResource("2")
+
+[node name="Player" type="CharacterBody2D" parent="."]
+script = ExtResource("1")

--- a/Player.gd
+++ b/Player.gd
@@ -1,0 +1,16 @@
+extends CharacterBody2D
+
+var speed := 100
+
+func _physics_process(delta):
+    var input_vector = Vector2.ZERO
+    if Input.is_action_pressed("ui_right"):
+        input_vector.x += 1
+    if Input.is_action_pressed("ui_left"):
+        input_vector.x -= 1
+    if Input.is_action_pressed("ui_down"):
+        input_vector.y += 1
+    if Input.is_action_pressed("ui_up"):
+        input_vector.y -= 1
+    velocity = input_vector.normalized() * speed
+    move_and_slide()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # GetAJobGame
+
+This repository contains a very small Godot 4 prototype. It includes a
+simple player that can move around and a basic farm grid made from
+dynamically generated tiles. The project is configured to autoload the
+`GameManager.gd` and `LocationManager.gd` scripts and uses `Main.tscn`
+as the main scene.
+
+Open the project in Godot 4 to see the player moving on a 5x5 grid of
+farm tiles.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,21 @@
+[application]
+config/name="Corporate Life Simulator"
+run/main_scene="res://Main.tscn"
+config/icon="res://icon.svg"
+
+[autoload]
+GameManager="*res://GameManager.gd"
+LocationManager="*res://LocationManager.gd"
+
+[display]
+window/size/viewport_width=1280
+window/size/viewport_height=720
+
+[input]
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"device":0,"keycode":32,"pressed":false)]
+}
+
+[rendering]
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
## Summary
- implement `FarmTile.gd` with tile states
- create `FarmGrid.gd` to generate a small field
- add a basic `Player.gd` script
- update `Main.tscn` to include farm and player nodes
- document the setup in `README.md`

## Testing
- `ls -1`

------
https://chatgpt.com/codex/tasks/task_e_6853488ae8288329b2bf5e9eb5c9e7f7