### PR TITLE
Add simple playable job board demo

### DIFF
--- a/Calendar.gd
+++ b/Calendar.gd
@@ -1,0 +1,15 @@
+extends Node
+
+# Tracks in-game date and triggers daily events.
+var current_day := 1
+var current_month := 1
+var current_year := 1
+
+func next_day():
+    current_day += 1
+    if current_day > 30:
+        current_day = 1
+        current_month += 1
+    if current_month > 12:
+        current_month = 1
+        current_year += 1

--- a/GameManager.gd
+++ b/GameManager.gd
@@ -1,0 +1,28 @@
+extends Node
+
+## Manages global player stats and day progression.
+
+signal stats_changed
+
+var money := 1000
+var energy := 100
+var happiness := 50
+var day := 1
+var current_job := null
+
+func change_money(amount: int):
+    money += amount
+    emit_signal("stats_changed")
+
+func change_energy(amount: int):
+    energy = clamp(energy + amount, 0, 100)
+    emit_signal("stats_changed")
+
+func change_happiness(amount: int):
+    happiness = clamp(happiness + amount, 0, 100)
+    emit_signal("stats_changed")
+
+func next_day():
+    day += 1
+    energy = 100
+    emit_signal("stats_changed")

--- a/HUD.gd
+++ b/HUD.gd
@@ -1,0 +1,20 @@
+extends CanvasLayer
+
+@onready var money_label = $Panel/Money
+@onready var energy_label = $Panel/Energy
+@onready var day_label = $Panel/Day
+@onready var happiness_label = $Panel/Happiness
+@onready var job_label = $Panel/Job
+
+func _ready():
+    var gm = get_node("/root/GameManager")
+    gm.connect("stats_changed", Callable(self, "update_labels"))
+    update_labels()
+
+func update_labels():
+    var gm = get_node("/root/GameManager")
+    money_label.text = "Money: $%d" % gm.money
+    energy_label.text = "Energy: %d" % gm.energy
+    day_label.text = "Day: %d" % gm.day
+    happiness_label.text = "Happiness: %d" % gm.happiness
+    job_label.text = gm.current_job != null ? "Job: %s" % gm.current_job.job_title : "Job: None"

--- a/HUD.tscn
+++ b/HUD.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://HUD.gd" type="Script" id="1"]
+
+[node name="HUD" type="CanvasLayer"]
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+
+[node name="Money" type="Label" parent="Panel"]
+position = Vector2(10, 10)
+text = "Money:"
+
+[node name="Energy" type="Label" parent="Panel"]
+position = Vector2(10, 30)
+text = "Energy:"
+
+[node name="Day" type="Label" parent="Panel"]
+position = Vector2(10, 50)
+text = "Day:"
+
+[node name="Happiness" type="Label" parent="Panel"]
+position = Vector2(150, 10)
+text = "Happiness:"
+
+[node name="Job" type="Label" parent="Panel"]
+position = Vector2(150, 30)
+text = "Job:"

--- a/JobBoard.gd
+++ b/JobBoard.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+# Displays available jobs on a simple grid.
+const GRID_WIDTH := 5
+const GRID_HEIGHT := 1
+const TILE_SIZE := 64
+
+var listings = []
+
+func _ready():
+    var listing_scene = preload("res://JobListing.tscn")
+    for x in range(GRID_WIDTH):
+        var listing = listing_scene.instantiate()
+        listing.position = Vector2(x * TILE_SIZE, 0)
+        listing.job_title = "Job %d" % (x + 1)
+        listing.salary = 100 + x * 50
+        add_child(listing)
+        listings.append(listing)
+
+func get_listing_near(pos: Vector2) -> Node:
+    for listing in listings:
+        if listing.position.distance_to(pos) < TILE_SIZE / 2:
+            return listing
+    return null

--- a/JobListing.gd
+++ b/JobListing.gd
@@ -1,0 +1,56 @@
+extends Node2D
+
+## Represents a single job listing the player can interact with.
+enum State { OPEN, APPLIED, INTERVIEWED, HIRED }
+var state : State = State.OPEN
+
+var job_title := "Job"
+var salary := 100
+@onready var label := $Label
+@onready var gm := get_node("/root/GameManager")
+
+func _ready():
+    update()
+
+func _draw():
+    # Use different colors based on the progress of the job application.
+    var color = Color(0.4, 0.3, 0.1)
+    match state:
+        State.APPLIED:
+            color = Color(0.2, 0.4, 0.7)
+        State.INTERVIEWED:
+            color = Color(0.4, 0.6, 0.9)
+        State.HIRED:
+            color = Color(0.1, 0.8, 0.1)
+    draw_rect(Rect2(Vector2.ZERO, Vector2(32, 32)), color)
+    label.text = job_title
+
+func apply():
+    if state == State.OPEN:
+        state = State.APPLIED
+        update()
+
+func interview():
+    if state == State.APPLIED:
+        state = State.INTERVIEWED
+        update()
+
+func hire():
+    if state == State.INTERVIEWED:
+        state = State.HIRED
+        update()
+
+func interact():
+    match state:
+        State.OPEN:
+            apply()
+            gm.change_energy(-10)
+        State.APPLIED:
+            interview()
+            gm.change_energy(-15)
+        State.INTERVIEWED:
+            hire()
+        State.HIRED:
+            gm.change_money(salary)
+            gm.change_energy(-20)
+            gm.change_happiness(1)

--- a/JobListing.tscn
+++ b/JobListing.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://JobListing.gd" type="Script" id="1"]
+
+[node name="JobListing" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Label" type="Label" parent="."]
+position = Vector2(0, -20)
+text = "Job"

--- a/LocationManager.gd
+++ b/LocationManager.gd
@@ -1,0 +1,6 @@
+extends Node
+
+# Placeholder autoload script
+
+func _ready():
+    pass

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://Player.gd" type="Script" id="1"]
+[ext_resource path="res://JobBoard.gd" type="Script" id="2"]
+[ext_resource path="res://HUD.tscn" type="PackedScene" id="3"]
+
+[node name="Main" type="Node2D"]
+
+[node name="JobBoard" type="Node2D" parent="."]
+script = ExtResource("2")
+
+[node name="Player" type="CharacterBody2D" parent="."]
+script = ExtResource("1")
+
+[node name="HUD" parent="." instance=ExtResource("3")]

--- a/NPC.gd
+++ b/NPC.gd
@@ -1,0 +1,13 @@
+extends Node2D
+
+var name := ""
+var dialogue := []
+var current_line := 0
+
+func talk():
+    if current_line < dialogue.size():
+        var line = dialogue[current_line]
+        current_line += 1
+        return line
+    current_line = 0
+    return ""

--- a/Player.gd
+++ b/Player.gd
@@ -1,0 +1,24 @@
+extends CharacterBody2D
+
+var speed := 100
+
+@onready var job_board := get_parent().get_node("JobBoard")
+@onready var gm := get_node("/root/GameManager")
+
+func _physics_process(delta):
+    var input_vector = Vector2.ZERO
+    if Input.is_action_pressed("ui_right"):
+        input_vector.x += 1
+    if Input.is_action_pressed("ui_left"):
+        input_vector.x -= 1
+    if Input.is_action_pressed("ui_down"):
+        input_vector.y += 1
+    if Input.is_action_pressed("ui_up"):
+        input_vector.y -= 1
+    velocity = input_vector.normalized() * speed
+    move_and_slide()
+
+    if Input.is_action_just_pressed("ui_accept"):
+        var listing = job_board.get_listing_near(position)
+        if listing:
+            listing.interact()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # GetAJobGame
+
+This repository contains a small Godot 4 prototype for a job-searching
+life simulator. The player can move around and interact with a simple
+`JobBoard` of listings. Autoload scripts (`GameManager.gd`,
+`LocationManager.gd`, and `Calendar.gd`) provide basic structure while
+`Main.tscn` loads a minimal scene.
+
+Open the project in Godot 4 and press **Play**. Use the arrow keys to move
+the player toward one of the job listings. Press the **Space** key while
+standing next to a listing to interact. Each interaction progresses the
+application from applying to interviewing, hiring, and finally working the
+job for a small salary. A simple HUD at the top left shows money,
+energy, happiness and the current day.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,22 @@
+[application]
+config/name="Corporate Life Simulator"
+run/main_scene="res://Main.tscn"
+config/icon="res://icon.svg"
+
+[autoload]
+GameManager="*res://GameManager.gd"
+LocationManager="*res://LocationManager.gd"
+Calendar="*res://Calendar.gd"
+
+[display]
+window/size/viewport_width=1280
+window/size/viewport_height=720
+
+[input]
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"device":0,"keycode":32,"pressed":false)]
+}
+
+[rendering]
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
## Summary
- add HUD scene for displaying stats
- implement `GameManager.gd` with basic stat tracking
- expand `JobListing.gd` and `JobBoard.gd` for simple interaction
- update `Player.gd` with interaction logic
- tweak main scene and README instructions

## Testing
- `ls -1`


------
https://chatgpt.com/codex/tasks/task_e_6853488ae8288329b2bf5e9eb5c9e7f7